### PR TITLE
Add jq to the base install

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,6 +7,11 @@ tasks:
     desc: install age, an encryption / decryption tool
     cmds:
       - apt install age
+  install:jq:
+    aliases: [jqinstall]
+    desc: install jq
+    cmds:
+      - sudo apt-get install jq
   install:docker:
     aliases: [dockerinstall]
     desc: pulls down the docker installation script and runs it
@@ -71,6 +76,7 @@ tasks:
   fullinstall:
     desc: runs through all of the respective installation tasks
     cmds:
+      - task: jqinstall
       - task: dockerinstall
       - task: privs
       - task: setupssh


### PR DESCRIPTION
jq is a common tool used to parse JSON in bash scripts and should be installed on our runners by default